### PR TITLE
fix wrong use of CAMLlocal

### DIFF
--- a/lib/milter_stubs.c
+++ b/lib/milter_stubs.c
@@ -460,7 +460,7 @@ milter_close(SMFICTX *ctx)
 static sfsistat
 milter_unknown(SMFICTX *ctx, const char *cmd)
 {
-    CAMLlocal3(ret, ctx_val, cmd_val);
+    value ret, ctx_val, cmd_val;
     static value *closure = NULL;
     sfsistat s;
 


### PR DESCRIPTION
You cannot use `CAMLlocal` outside the scope of a `CAMLparam`, and OCaml 4.04.0 will catch this mistake by causing a compilation error.

This particular line is probably the cause of some random GC crashes.
